### PR TITLE
added the ability to add child items in the block "item"

### DIFF
--- a/Feed.php
+++ b/Feed.php
@@ -216,6 +216,24 @@ class Feed extends DOMDocument
         $this->item->appendChild($element);
         return $this;
     }
+    
+    public function addItemElementSub($element, $sub)
+    {
+        $element = $this->createElement($element);
+        foreach ($sub as $key => $value) {
+            if (is_array($value)) {
+                $subElement = $this->createElement($key);
+                foreach ($value as $key => $value) {
+                    $subElement->setAttribute($key, $this->normalizeString($value));
+                }
+            } else {
+                $subElement = $this->createElement($key, $this->normalizeString($value));
+            }
+            $element->appendChild($subElement);
+        }
+        $this->item->appendChild($element);
+        return $this;
+    }
 
     public function addItemTitle($value)
     {

--- a/example.php
+++ b/example.php
@@ -55,6 +55,7 @@ $feed
     ->addItemSource('RSS title', 'http://example.com/rss.xml');
 
 $feed->addItemElement('test', 'desc', array('attr1' => 'val1', 'attr2' => 'val2'));
+$feed->addItemElementSub('group', [ 'var1' => ['key1' => 'value1' ], 'var2' => ['key2' => 'value2' ]]);
 
 echo $feed;
 // $feed->save(realpath(__DIR__ . '/rss.xml'));


### PR DESCRIPTION
It may need when using such Yandex News: 

example result:

```
<item>
    <media:group>
        <media:content url="link"/>
        <media:player url="link"/>
        <media:thumbnail url="link"/>
    </media:group>
</item>
```

method call example:

```
$feed->addItemElementSub('media:group', [
                        'media:content' => [
                            'url' => 'link'
                        ], 
                        'media:player' => [
                            'url' => 'link'
                        ],
                        'media:thumbnail' => [
                            'url' => 'link'
                        ]
                    ]);
```
